### PR TITLE
fix: 검색 결과와 상세보기 불일치 해결

### DIFF
--- a/app/src/main/java/com/dasom/khuhelper/user/UserActivity.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/UserActivity.java
@@ -178,11 +178,10 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
     private void markChargingStation(ArrayList<ChargingStation> chargingStations) {
         MapPOIItem mapPOIItem;
         Log.d("Mark Carging Station", "마커표시시작");
-        int tag=0;
         for (ChargingStation cs : chargingStations) {
             mapPOIItem = new MapPOIItem();
             mapPOIItem.setItemName(cs.getStatNm());
-            mapPOIItem.setTag(tag++);
+            mapPOIItem.setTag(cs.getStatTag());
             mapPOIItem.setMapPoint(MapPoint.mapPointWithGeoCoord(cs.getLat(), cs.getLng()));
             mapPOIItem.setMarkerType(MapPOIItem.MarkerType.CustomImage); // 마커타입을 커스텀 마커로 지정.
             mapPOIItem.setCustomImageResourceId(R.drawable.ic_ev_place); // 마커 이미지.

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStation.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStation.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 public class ChargingStation implements Serializable {
 
+    private int statTag; // 마커용 tag (csList index)
     private String statId; // 충전소ID (고유값)
     private String statNm; // 충전소 이름
     private int chgerType; // 충전기 타입
@@ -12,6 +13,14 @@ public class ChargingStation implements Serializable {
     private Float lat; // 위도
     private Float lng; // 경도
     private String useTime; // 이용시간
+
+    public int getStatTag() {
+        return statTag;
+    }
+
+    public void setStatTag(int statTag) {
+        this.statTag = statTag;
+    }
 
     public void setStatId(String statId) {
         this.statId = statId;

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
@@ -67,6 +67,8 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
             xpp.next();
             eventType = xpp.getEventType();
 
+            int statTag = 0; // 마커표시를 위한 tag
+
             while( eventType != XmlPullParser.END_DOCUMENT ){
                 switch( eventType ){
                     case XmlPullParser.START_DOCUMENT:
@@ -78,6 +80,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
                         if (tag.equals("item")) {
                             ChargingStation cs = setChargingStation();
                             if (cs != null) {
+                                cs.setStatTag(statTag++);
                                 csList.add(cs);
                             }
                         }


### PR DESCRIPTION
#43 

## 문제상황
검색을 하면 검색결과는 잘 뜨는데, 마커를 클릭해서 상세정보를 보면 전혀 다른 충전소가 뜸!

## 원인
기존에 map에 marker을 표시할 때 `tag++` 로 구별을 해줬다. 
balloon을 클릭해서 상세정보로 갈 때는 `csList`에서 tag로 검색을 하는데, (tag가 단순 csList의 index역할) 위처럼 검색 후에 tag를 걍 `++` 해버리니까 리스트의 index와 맞지 않던 것!

## 해결
두 가지 방법을 생각했었다.
1. 검색 할 때마다 XML파싱을 새로 하고, csList 교체하기
해당 쿼리를 지원하진 않는데, 코드상으로 할 수 있겠다고 생각했음.
2. `ChargingStation` 클래스에 tag 필드 추가하기! ✔️
데이터를 파싱할 때 순서대로 (csList에 들어가는 순서) tag를 저장해두기! 그리고 marker를 표시할 때 이 tag를 받아와서 저장하기

-> 2번으로 결정
> 1번이 좀 더 실시간인 것 같긴 한데.. 뭐가 더 맞는 방식인지는 모르겠다! 난 일단 앱을 실행할 때 마다 데이터를 한번 가져온 다음에 계속 쓰는걸로..! 다음에는 ChargingStation 에 저장하지 말고, 데이터를 받아와서 바로바로 표시하는 것도 괜찮을 것 같다! 사용자의 폰에 저장할 필요는 없으니까

### 문제발생
station id 받는 곳에서 tag를 저장했는데, tag가 도약을 함...!! 
![image](https://user-images.githubusercontent.com/37680108/112941101-07008400-9169-11eb-8d1e-a4ab191f3b80.png)

-> 아래처럼 바꿔서 해결!
```
if (cs != null) {
    cs.setStatTag(statTag++);
    csList.add(cs);
}
```
![image](https://user-images.githubusercontent.com/37680108/112941127-0c5dce80-9169-11eb-84c8-4052ad15740d.png)

## 성공 스샷
![image](https://user-images.githubusercontent.com/37680108/112941165-1c75ae00-9169-11eb-9358-1fea056fb8f1.png)
