### PR TITLE
API 변경, 검색결과 예외처리

### DIFF
--- a/app/src/main/java/com/dasom/khuhelper/user/PlaceActivity.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/PlaceActivity.java
@@ -67,15 +67,15 @@ public class PlaceActivity extends AppCompatActivity implements View.OnClickList
 
     private void setInformation() {
         nameTv.setText(chargingStation.getStatNm());
-        operTimeTv.setText(chargingStation.getUseTime());
+        operTimeTv.setText("Update : " + chargingStation.getUseTime());
         switch (chargingStation.getChgerType()) {
-            case 01:
+            case 1:
                 batteryTypeTv.setText("DC 차데모");
                 break;
-            case 03:
+            case 2:
                 batteryTypeTv.setText("DC 차데모 + AC 3상");
                 break;
-            case 06:
+            case 6:
                 batteryTypeTv.setText("DC 차데모 + AD 3상 + DC 콤보");
                 break;
         }

--- a/app/src/main/java/com/dasom/khuhelper/user/UserActivity.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/UserActivity.java
@@ -156,12 +156,16 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
         imm.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
 
         mapView.removeAllPOIItems();
-        markChargingStation(chargingStationParser.getStationByName(name));
-        StringBuilder builder = new StringBuilder()
-                .append(name)
-                .append("(와)과 관련된 충전소가 표시되었습니다.");
-        Toast.makeText(UserActivity.this, builder, Toast.LENGTH_SHORT).show();
-        mapView.fitMapViewAreaToShowAllPOIItems();
+        if (markChargingStation(chargingStationParser.getStationByName(name))) {
+            StringBuilder builder = new StringBuilder()
+                    .append(name)
+                    .append("(와)과 관련된 충전소가 표시되었습니다.");
+            Toast.makeText(UserActivity.this, builder, Toast.LENGTH_SHORT).show();
+            mapView.fitMapViewAreaToShowAllPOIItems();
+        } else {
+            Toast.makeText(UserActivity.this, "검색 결과가 없습니다.", Toast.LENGTH_SHORT).show();
+        }
+
     }
 
     private void parseChargingStation() {
@@ -175,7 +179,8 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
         chargingStationParser.execute();
     }
 
-    private void markChargingStation(ArrayList<ChargingStation> chargingStations) {
+    private boolean markChargingStation(ArrayList<ChargingStation> chargingStations) {
+        if (chargingStations.size() == 0) return false;
         MapPOIItem mapPOIItem;
         Log.d("Mark Carging Station", "마커표시시작");
         for (ChargingStation cs : chargingStations) {
@@ -189,5 +194,6 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
             mapPOIItem.setCustomImageAnchor(0.5f, 1.0f); // 마커 이미지중 기준이 되는 위치(앵커포인트) 지정 - 마커 이미지 좌측 상단 기준 x(0.0f ~ 1.0f), y(0.0f ~ 1.0f) 값.
             mapView.addPOIItem(mapPOIItem);
         }
+        return true;
     }
 }

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
@@ -159,7 +159,6 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
                         break;
 
                     case XmlPullParser.END_TAG:
-//                        if(tag.equals("item")) return tmpStation;
                         if (isEndTag) return tmpStation;
                         isEndTag = true;
                 }

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
@@ -29,7 +29,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
         this.cspCallBack = cspCallBack;
         csList = new ArrayList<>();
         queryURL = "http://openapi.kepco.co.kr/service/EvInfoServiceV2/getEvSearchList?"//요청 URL
-                +"serviceKey=" + ServiceKey.key + "&numOfRows=" + 5000;
+                +"serviceKey=" + ServiceKey.key + "&numOfRows=" + 5000 + "&addr=서울특별시";
     }
 
     public ChargingStation findStationByTag(int tag) {
@@ -126,14 +126,14 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
 
 
                         isEndTag = false;
-                        if (tag.equals("cpTp") || tag.equals("csId") || tag.equals("statUpdatedatetime")) {
+                        if (tag.equals("cpTp") || tag.equals("cpId") || tag.equals("cpNm")) {
                             xpp.next();
                         }
                         else {
-                            if (tag.equals("cpId")) {
+                            if (tag.equals("csId")) {
                                 xpp.next();
                                 tmpStation.setStatId(xpp.getText());
-                            } else if (tag.equals("cpNm")) {
+                            } else if (tag.equals("csNm")) {
                                 xpp.next();
                                 tmpStation.setStatNm(xpp.getText());
                             } else if (tag.equals("chargeTp")) {
@@ -144,9 +144,6 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
                                 tmpStation.setStat(Integer.parseInt(xpp.getText()));
                             } else if (tag.equals("addr")) {
                                 xpp.next();
-                                if (!xpp.getText().contains("서울특별시")) {
-                                    return null;
-                                }
                                 tmpStation.setAddrDoro(xpp.getText());
                             } else if (tag.equals("lat")) {
                                 xpp.next();
@@ -154,7 +151,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
                             } else if (tag.equals("longi")) {
                                 xpp.next();
                                 tmpStation.setLng(Float.parseFloat(xpp.getText()));
-                            } else if (tag.equals("useTime")) {
+                            } else if (tag.equals("statUpdateDatetime")) {
                                 xpp.next();
                                 tmpStation.setUseTime(xpp.getText());
                             }

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
@@ -28,8 +28,8 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
     public ChargingStationParser(ChargingStationParserCallBack cspCallBack) {
         this.cspCallBack = cspCallBack;
         csList = new ArrayList<>();
-        queryURL = "http://open.ev.or.kr:8080/openapi/services/rest/EvChargerService?"//요청 URL
-                +"serviceKey=" + ServiceKey.key;
+        queryURL = "http://openapi.kepco.co.kr/service/EvInfoServiceV2/getEvSearchList?"//요청 URL
+                +"serviceKey=" + ServiceKey.key + "&numOfRows=" + 5000;
     }
 
     public ChargingStation findStationByTag(int tag) {
@@ -122,48 +122,47 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
                         break;
 
                     case XmlPullParser.START_TAG:
-                        isEndTag = false;
                         tag = xpp.getName(); //태그 이름 얻어오기
 
-                        if(tag.equals("statId")){
-                            xpp.next();
-                            tmpStation.setStatId(xpp.getText());
-                        }
-                        else if(tag.equals("statNm")){
-                            xpp.next();
-                            tmpStation.setStatNm(xpp.getText());
-                        }
-                        else if(tag.equals("chgerType")){
-                            xpp.next();
-                            tmpStation.setChgerType(Integer.parseInt(xpp.getText()));
-                        }
-                        else if(tag.equals("stat")){
-                            xpp.next();
-                            tmpStation.setStat(Integer.parseInt(xpp.getText()));
-                        }
-                        else if(tag.equals("addrDoro")){
-                            xpp.next();
-                            if(!xpp.getText().contains("서울특별시")) {
-                                return null;
-                            }
-                            tmpStation.setAddrDoro(xpp.getText());
-                        }
-                        else if(tag.equals("lat")){
-                            xpp.next();
-                            tmpStation.setLat(Float.parseFloat(xpp.getText()));
-                        }
-                        else if(tag.equals("lng")){
-                            xpp.next();
-                            tmpStation.setLng(Float.parseFloat(xpp.getText()));
-                        }
-                        else if(tag.equals("useTime")){
-                            xpp.next();
-                            tmpStation.setUseTime(xpp.getText());
-                        }
 
+                        isEndTag = false;
+                        if (tag.equals("cpTp") || tag.equals("csId") || tag.equals("statUpdatedatetime")) {
+                            xpp.next();
+                        }
+                        else {
+                            if (tag.equals("cpId")) {
+                                xpp.next();
+                                tmpStation.setStatId(xpp.getText());
+                            } else if (tag.equals("cpNm")) {
+                                xpp.next();
+                                tmpStation.setStatNm(xpp.getText());
+                            } else if (tag.equals("chargeTp")) {
+                                xpp.next();
+                                tmpStation.setChgerType(Integer.parseInt(xpp.getText()));
+                            } else if (tag.equals("cpStat")) {
+                                xpp.next();
+                                tmpStation.setStat(Integer.parseInt(xpp.getText()));
+                            } else if (tag.equals("addr")) {
+                                xpp.next();
+                                if (!xpp.getText().contains("서울특별시")) {
+                                    return null;
+                                }
+                                tmpStation.setAddrDoro(xpp.getText());
+                            } else if (tag.equals("lat")) {
+                                xpp.next();
+                                tmpStation.setLat(Float.parseFloat(xpp.getText()));
+                            } else if (tag.equals("longi")) {
+                                xpp.next();
+                                tmpStation.setLng(Float.parseFloat(xpp.getText()));
+                            } else if (tag.equals("useTime")) {
+                                xpp.next();
+                                tmpStation.setUseTime(xpp.getText());
+                            }
+                        }
                         break;
 
                     case XmlPullParser.END_TAG:
+//                        if(tag.equals("item")) return tmpStation;
                         if (isEndTag) return tmpStation;
                         isEndTag = true;
                 }


### PR DESCRIPTION
# 1. API 변경 #53 
## 상황파악
기존의 API가 무슨 이유인지 동작하지 않는다.. 아마 구 버전이라 그런듯! 
사실 이전의 API가 오래된 걸 알면서도 `충전기 이용시간`이 있어서 선택했었다

## 해결방법
API 발급받고, `queryURL` 바꿔주면 끝.. 이 아니고
parsing하는 부분 수정이 필요했다.

그래도 장점은 도로명주소 필터옵션이 생겼음!
-> 예전엔 지도에 서울만 표시하기 위해 코드로 처리했는데, 깔끔하게 쿼리로 가능해짐

새로운 데이터 아이템 내용
```xml
<item>
<addr>서울특별시 중구 남대문로 92 1층 주차장</addr>
<chargeTp>2</chargeTp>
<cpId>811</cpId>
<cpNm>급속01</cpNm>
<cpStat>1</cpStat>
<cpTp>10</cpTp>
<csId>14</csId>
<csNm>서울직할</csNm>
<lat>37.565199</lat>
<longi>126.983339</longi>
<statUpdateDatetime>2021-04-13 12:16:50</statUpdateDatetime>
</item>
```

# 2 검색 결과 없을 때 예외처리 #52 
## 상황파악
검색 결과가 없어도 `''와 관련된 결과입니다~` 하는 토스트 메시지가 떴다.

## 해결방법
예외처리 함 ~~ 
검색 후 리스트의 크기가 0이면 `검색 결과가 없습니다` 출력
![image](https://user-images.githubusercontent.com/37680108/114557222-6a7bcd00-9ca4-11eb-8b2a-1edf6328557f.png)
