### PR TITLE
fix : 마커 표시를 비동기로 변경함

### DIFF
--- a/app/src/main/java/com/dasom/khuhelper/user/UserActivity.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/UserActivity.java
@@ -156,7 +156,7 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
         imm.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
 
         mapView.removeAllPOIItems();
-        if (markChargingStation(chargingStationParser.getStationByName(name))) {
+        if (markChargingStation(chargingStationParser.getStationsByName(name))) {
             StringBuilder builder = new StringBuilder()
                     .append(name)
                     .append("(와)과 관련된 충전소가 표시되었습니다.");
@@ -172,8 +172,8 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
         // 충전소 파서 실행 (AsyncTask)
         chargingStationParser = new ChargingStationParser(new ChargingStationParserCallBack() {
             @Override
-            public void onSuccess(ArrayList<ChargingStation> chargingStations) {
-                markChargingStation(chargingStations);
+            public void onSuccess(ChargingStation chargingStation) {
+                markChargingStation(chargingStation);
             }
         });
         chargingStationParser.execute();
@@ -181,19 +181,26 @@ public class UserActivity extends AppCompatActivity implements View.OnClickListe
 
     private boolean markChargingStation(ArrayList<ChargingStation> chargingStations) {
         if (chargingStations.size() == 0) return false;
-        MapPOIItem mapPOIItem;
         Log.d("Mark Carging Station", "마커표시시작");
+        boolean isSuccess = false;
         for (ChargingStation cs : chargingStations) {
-            mapPOIItem = new MapPOIItem();
-            mapPOIItem.setItemName(cs.getStatNm());
-            mapPOIItem.setTag(cs.getStatTag());
-            mapPOIItem.setMapPoint(MapPoint.mapPointWithGeoCoord(cs.getLat(), cs.getLng()));
-            mapPOIItem.setMarkerType(MapPOIItem.MarkerType.CustomImage); // 마커타입을 커스텀 마커로 지정.
-            mapPOIItem.setCustomImageResourceId(R.drawable.ic_ev_place); // 마커 이미지.
-            mapPOIItem.setCustomImageAutoscale(false); // hdpi, xhdpi 등 안드로이드 플랫폼의 스케일을 사용할 경우 지도 라이브러리의 스케일 기능을 꺼줌.
-            mapPOIItem.setCustomImageAnchor(0.5f, 1.0f); // 마커 이미지중 기준이 되는 위치(앵커포인트) 지정 - 마커 이미지 좌측 상단 기준 x(0.0f ~ 1.0f), y(0.0f ~ 1.0f) 값.
-            mapView.addPOIItem(mapPOIItem);
+            isSuccess = markChargingStation(cs);
         }
+        return isSuccess;
+    }
+
+    private boolean markChargingStation(ChargingStation cs) {
+        MapPOIItem mapPOIItem;
+        Log.d("Mark Carging Station", "마커표시");
+        mapPOIItem = new MapPOIItem();
+        mapPOIItem.setItemName(cs.getStatNm());
+        mapPOIItem.setTag(cs.getStatTag());
+        mapPOIItem.setMapPoint(MapPoint.mapPointWithGeoCoord(cs.getLat(), cs.getLng()));
+        mapPOIItem.setMarkerType(MapPOIItem.MarkerType.CustomImage); // 마커타입을 커스텀 마커로 지정.
+        mapPOIItem.setCustomImageResourceId(R.drawable.ic_ev_place); // 마커 이미지.
+        mapPOIItem.setCustomImageAutoscale(false); // hdpi, xhdpi 등 안드로이드 플랫폼의 스케일을 사용할 경우 지도 라이브러리의 스케일 기능을 꺼줌.
+        mapPOIItem.setCustomImageAnchor(0.5f, 1.0f); // 마커 이미지중 기준이 되는 위치(앵커포인트) 지정 - 마커 이미지 좌측 상단 기준 x(0.0f ~ 1.0f), y(0.0f ~ 1.0f) 값.
+        mapView.addPOIItem(mapPOIItem);
         return true;
     }
 }

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParser.java
@@ -30,6 +30,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
         csList = new ArrayList<>();
         queryURL = "http://openapi.kepco.co.kr/service/EvInfoServiceV2/getEvSearchList?"//요청 URL
                 +"serviceKey=" + ServiceKey.key + "&numOfRows=" + 5000 + "&addr=서울특별시";
+        // TODO: 2021/09/05 화면에 보이는 영역만 충전소 위치 받아서 표시 (클러스터링까지 되면 좋겠다)
     }
 
     public ChargingStation findStationByTag(int tag) {
@@ -42,7 +43,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
      * @param name
      * @return
      */
-    public ArrayList<ChargingStation> getStationByName(String name) {
+    public ArrayList<ChargingStation> getStationsByName(String name) {
         ArrayList<ChargingStation> findList = new ArrayList<>();
 
         for (ChargingStation cs : csList) {
@@ -82,6 +83,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
                             if (cs != null) {
                                 cs.setStatTag(statTag++);
                                 csList.add(cs);
+                                cspCallBack.onSuccess(cs); // 마커표시
                             }
                         }
                         break;
@@ -107,7 +109,7 @@ public class ChargingStationParser extends AsyncTask<Void, Void, Void> {
     @Override
     protected void onPostExecute(Void vd) {
         super.onPostExecute(vd);
-        cspCallBack.onSuccess(csList);
+        Log.d("Parser", "onPostExecute");
     }
 
     private ChargingStation setChargingStation() {

--- a/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParserCallBack.java
+++ b/app/src/main/java/com/dasom/khuhelper/user/map/ChargingStationParserCallBack.java
@@ -1,7 +1,5 @@
 package com.dasom.khuhelper.user.map;
 
-import java.util.ArrayList;
-
 public interface ChargingStationParserCallBack {
-    void onSuccess(ArrayList<ChargingStation> chargingStations);
+    void onSuccess(ChargingStation chargingStation);
 }


### PR DESCRIPTION
Relate : #40

## 기존
충전소 파싱은 비동기로 했으나, 전체 파싱 완료 후 main thread에서 마커 표시를 했다.
-> 너무 느려서 서울만 표시했었음

## 현재
비동기로 충전소를 파싱하며 마커 표시를 진행함. (callback)
로그를 보면 모든 파싱이 끝나기 전에 마커표시가 됨을 알 수 있다.
![image](https://user-images.githubusercontent.com/37680108/132117519-5162d4f0-88fd-46ef-aea1-7ef39c541e31.png)
-> 여전히 전국 전체를 표시하는 것은 느려서 서울만 표시함.
그래도 마커를 표시하는 도중 조작이 가능해졌다.
